### PR TITLE
Transform features public member function

### DIFF
--- a/src/hnsw/hnsw_const.rs
+++ b/src/hnsw/hnsw_const.rs
@@ -320,7 +320,7 @@ where
         self.search_zero_layer(q, searcher, cap);
 
         let found = core::cmp::min(dest.len(), searcher.nearest.len());
-        dest.copy_from_slice(&searcher.nearest[..found]);
+        dest[..found].copy_from_slice(&searcher.nearest[..found]);
         &mut dest[..found]
     }
 

--- a/src/hnsw/hnsw_const.rs
+++ b/src/hnsw/hnsw_const.rs
@@ -63,6 +63,21 @@ where
             params,
         }
     }
+
+    pub fn transform_features<T2, F>(self, f: F) -> Hnsw<Met, T2, R, M, M0>
+    where
+        F: Fn(T) -> T2,
+    {
+        let features = self.features.into_iter().map(f).collect();
+        Hnsw {
+            metric: self.metric,
+            zero: self.zero,
+            features,
+            layers: self.layers,
+            prng: self.prng,
+            params: self.params,
+        }
+    }
 }
 
 impl<Met, T, R, const M: usize, const M0: usize> Knn for Hnsw<Met, T, R, M, M0>


### PR DESCRIPTION
We have a backing store for the HNSW and need to be able to convert between a serialisable representation which is essentially an id of the vectors and the vectors themselves as they exist in the backing store, but do not want to drift too far from the original HNSW library. Is it possible to include this function or a variant in the library?