### PR TITLE
fix: copy_from_slice panic when k > number of indexed elements

### DIFF
--- a/src/hnsw/hnsw_const.rs
+++ b/src/hnsw/hnsw_const.rs
@@ -306,7 +306,7 @@ where
             self.search_single_layer(q, searcher, Layer::NonZero(layer), cap);
             if ix + 1 == level {
                 let found = core::cmp::min(dest.len(), searcher.nearest.len());
-                dest.copy_from_slice(&searcher.nearest[..found]);
+                dest[..found].copy_from_slice(&searcher.nearest[..found]);
                 return &mut dest[..found];
             }
             self.lower_search(layer, searcher);
@@ -318,7 +318,7 @@ where
         self.search_zero_layer(q, searcher, cap);
 
         let found = core::cmp::min(dest.len(), searcher.nearest.len());
-        dest.copy_from_slice(&searcher.nearest[..found]);
+        dest[..found].copy_from_slice(&searcher.nearest[..found]);
         &mut dest[..found]
     }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -147,3 +147,21 @@ fn nearest_neighbor() {
         assert_eq!(result, helper.search(&[0.0, 0.0, 0.0, 1.0], topk));
     }
 }
+
+#[test]
+fn nearest_k_greater_than_index_size() {
+    let (hnsw, mut searcher, _) = test_hnsw();
+    let searcher = &mut searcher;
+
+    // k=100 but index only has 8 elements — must not panic
+    let mut neighbors = vec![
+        Neighbor {
+            index: !0,
+            distance: !0,
+        };
+        100
+    ];
+    let found = hnsw.nearest(&&[0.0, 0.0, 0.0, 1.0][..], 100, searcher, &mut neighbors);
+    assert_eq!(found.len(), 8, "should return all 8 elements");
+    assert_eq!(found[0].index, 0, "closest should be index 0");
+}


### PR DESCRIPTION
## Bug

`search_layer` in `hnsw_const.rs` panics with a `copy_from_slice` length mismatch when the requested number of neighbors (`k` / `ef`) exceeds the number of elements in the index.

### Root cause

Two sites in `search_layer` (lines 309 and 321) use:

```rust
let found = core::cmp::min(dest.len(), searcher.nearest.len());
dest.copy_from_slice(&searcher.nearest[..found]);
```

`copy_from_slice` requires `src.len() == dest.len()`. When `found < dest.len()` (fewer elements in the index than requested), the source slice is shorter than `dest` → panic.

### Fix

```rust
dest[..found].copy_from_slice(&searcher.nearest[..found]);
```

Slices `dest` to match `found`, which is what the next line (`return &mut dest[..found]`) already expects.

### MRE

See `tests/simple.rs::nearest_k_greater_than_index_size` — inserts 8 vectors, searches with `k=100`:

```rust
#[test]
fn nearest_k_greater_than_index_size() {
    let (hnsw, mut searcher, _) = test_hnsw(); // 8 vectors
    let mut neighbors = vec![Neighbor { index: !0, distance: !0 }; 100];
    let found = hnsw.nearest(&&[0.0, 0.0, 0.0, 1.0][..], 100, &mut searcher, &mut neighbors);
    assert_eq!(found.len(), 8);
}
```

**Before:** panics with `copy_from_slice: source slice length (8) does not match destination slice length (100)`  
**After:** returns 8 results

This surfaces whenever a caller passes `k` larger than the index size, or when filtered searches reduce the effective candidate set below `k`.